### PR TITLE
added binding property to gunicorn config

### DIFF
--- a/app/gunicorn_config.py
+++ b/app/gunicorn_config.py
@@ -6,3 +6,5 @@ timeout = int(os.environ.get('GUNICORN_TIMEOUT', '120'))
 
 forwarded_allow_ips = '*'
 secure_scheme_headers = { 'X-Forwarded-Proto': 'https' }
+
+bind = "0.0.0.0:8080"


### PR DESCRIPTION
Building the predictions service using OpenShift's S2I creates a route & service to expose the app. The configuration of the service port mapping is based on the S2I builder image's Dockerfile.

By default, the app itself starts on a different port:

```shell
---> Serving application with gunicorn (wsgi) with custom settings ...
[2022-03-07 09:54:13 +0000] [1] [INFO] Starting gunicorn 20.1.0
[2022-03-07 09:54:13 +0000] [1] [INFO] Listening at: http://127.0.0.1:8000 (1)
```

To fix this, add the following line to `gunicorn_config.py`:

```python
bind = "0.0.0.0:8080"
```